### PR TITLE
Add Ruby 2.5 and 2.6 the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.10
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 before_install:
   - gem install bundler:1.17.3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
-  - 2.7
 before_install:
   - gem install bundler:1.17.3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.6
   - 2.7
 before_install:
-  - gem install bundler -v '~> 2.1.4'
+  - gem install bundler:1.17.3
 install:
   - bundle install
   - bundle install --gemfile=$PWD/spec/dummy/Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.6
   - 2.7
 before_install:
-  - gem install bundler:1.17.3
+  - gem install bundler -v '~> 2.1.4'
 install:
   - bundle install
   - bundle install --gemfile=$PWD/spec/dummy/Gemfile

--- a/rails_upgrader.gemspec
+++ b/rails_upgrader.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails-erd", "~> 1.5"
   spec.add_dependency "rails", "~> 3.2"
-  spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry-byebug", "~> 3.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
Couldn't include Ruby 2.7 in this PR as it has issues with Bundler 1.x which is a direct dependency of the Rails 3.2 dummy application inside tests.

Fixes #15
Fixes #16 