### PR TITLE
[CHORE]: Update PR template to remind about CHANGELOG entry

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,6 @@
-**IMPORTANT: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes. **
+**IMPORTANT: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.**
+
+- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.
 
 **Description:**
 


### PR DESCRIPTION
**IMPORTANT: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include _Closes #XXXX_ in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes. **

**Description:**

This PR adds a checkbox reminding the contributor to create a CHANGELOG entry.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).
