### PR TITLE
Add GitHub Actions workflow for Ruby 2.4.10 and Ruby 2.5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Ruby CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4.10', '2.5.7']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Install dependencies
+      run: |
+        gem install bundler:1.17.3
+        bundle install
+
+    - name: Install dummy app dependencies
+      run: |
+        bundle install --gemfile=$PWD/spec/dummy/Gemfile
+
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
+    - name: Upgrade RubyGems
+      run: gem update --system 3.2.3
+
+
     - name: Install dependencies
       run: |
         gem install bundler:1.17.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4.10
-before_install:
-  - gem install bundler:1.17.3
-install:
-  - bundle install
-  - bundle install --gemfile=$PWD/spec/dummy/Gemfile

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "pry"
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

## Description

Stop using Travis CI, start using GitHub Actions

## Motivation and Context

Travis CI kinda died.

## How Has This Been Tested?

Will test with CI. 

**I will abide by the [code of conduct](CODE_OF_CONDUCT.md)**
